### PR TITLE
Fix height conversion not being culture invariant

### DIFF
--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -1,4 +1,6 @@
 using System.Drawing;
+using System.Globalization;
+using System.Threading;
 using DotNetGraph.Extensions;
 using DotNetGraph.Node;
 using NFluent;
@@ -173,6 +175,64 @@ namespace DotNetGraph.Tests.Node
             var compiled = graph.Compile();
 
             Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [height=0.64]; }");
+        }
+        
+        [Fact]
+        public void NodeWithHeightUsesCorrectCulture()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
+            
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotNode("TestNode")
+                    {
+                        Height = 0.64f
+                    }
+                }
+            };
+
+            var cultureInfo = new CultureInfo("de-DE");
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+            
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [height=0.64]; }");
+            
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUiCulture;
+        }
+        
+        [Fact]
+        public void NodeWithLargeHeightUsesCorrectCulture()
+        {
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
+            
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotNode("TestNode")
+                    {
+                        Height = 12345.67f
+                    }
+                }
+            };
+
+            var cultureInfo = new CultureInfo("fr-FR");
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+            
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [height=12345.67]; }");
+            
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+            Thread.CurrentThread.CurrentUICulture = currentUiCulture;
         }
     }
 }

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Text;
 using DotNetGraph.Attributes;
 using DotNetGraph.Core;
@@ -192,7 +193,7 @@ namespace DotNetGraph.Compiler
                 }
                 else if (attribute is DotNodeHeightAttribute nodeHeightAttribute)
                 {
-                    attributeValues.Add($"height={nodeHeightAttribute.Value:F2}");
+                    attributeValues.Add(string.Format(CultureInfo.InvariantCulture, "height={0:F2}", nodeHeightAttribute.Value));
                 }
                 else if (attribute is DotEdgeArrowTailAttribute edgeArrowTailAttribute)
                 {


### PR DESCRIPTION
On systems with different culture info than en-US or similar the height
output was using a comma as decimal point, leading to an invalid dot
file that GraphViz is unable to parse