### PR TITLE
Add support for width attribute on nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ var myNode = new DotNode("MyNode")
     FillColor = Color.Coral,
     FontColor = Color.Black,
     Style = DotNodeStyle.Dotted,
+    Width = 0.5f,
     Height = 0.5f
 };
 

--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -159,6 +159,25 @@ namespace DotNetGraph.Tests.Node
         }
         
         [Fact]
+        public void NodeWithWidth()
+        {
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotNode("TestNode")
+                    {
+                        Width = 0.64f
+                    }
+                }
+            };
+
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [width=0.64]; }");
+        }
+        
+        [Fact]
         public void NodeWithHeight()
         {
             var graph = new DotGraph("TestGraph")
@@ -178,7 +197,7 @@ namespace DotNetGraph.Tests.Node
         }
         
         [Fact]
-        public void NodeWithHeightUsesCorrectCulture()
+        public void NodeWithWidthAndHeightUsesCorrectCulture()
         {
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
@@ -189,6 +208,7 @@ namespace DotNetGraph.Tests.Node
                 {
                     new DotNode("TestNode")
                     {
+                        Width = 0.46f,
                         Height = 0.64f
                     }
                 }
@@ -200,7 +220,7 @@ namespace DotNetGraph.Tests.Node
             
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [height=0.64]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [width=0.46,height=0.64]; }");
             
             Thread.CurrentThread.CurrentCulture = currentCulture;
             Thread.CurrentThread.CurrentUICulture = currentUiCulture;

--- a/Sources/DotNetGraph/Attributes/DotNodeWidthAttribute.cs
+++ b/Sources/DotNetGraph/Attributes/DotNodeWidthAttribute.cs
@@ -1,0 +1,24 @@
+using DotNetGraph.Core;
+
+namespace DotNetGraph.Attributes
+{
+    public class DotNodeWidthAttribute : IDotAttribute
+    {
+        public float Value { get; set; }
+
+        public DotNodeWidthAttribute(float value = default)
+        {
+            Value = value;
+        }
+        
+        public static implicit operator DotNodeWidthAttribute(float? value)
+        {
+            return value.HasValue ? new DotNodeWidthAttribute(value.Value) : null;
+        }
+
+        public static implicit operator DotNodeWidthAttribute(int? value)
+        {
+            return value.HasValue ? new DotNodeWidthAttribute(value.Value) : null;
+        }
+    }
+}

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -191,6 +191,10 @@ namespace DotNetGraph.Compiler
                     var text = FormatString(labelAttribute.Text);
                     attributeValues.Add($"label=\"{text}\"");
                 }
+                else if (attribute is DotNodeWidthAttribute nodeWidthAttribute)
+                {
+                    attributeValues.Add(string.Format(CultureInfo.InvariantCulture, "width={0:F2}", nodeWidthAttribute.Value));
+                }
                 else if (attribute is DotNodeHeightAttribute nodeHeightAttribute)
                 {
                     attributeValues.Add(string.Format(CultureInfo.InvariantCulture, "height={0:F2}", nodeHeightAttribute.Value));

--- a/Sources/DotNetGraph/Node/DotNode.cs
+++ b/Sources/DotNetGraph/Node/DotNode.cs
@@ -43,6 +43,12 @@ namespace DotNetGraph.Node
             set => SetAttribute(value);
         }
 
+        public DotNodeWidthAttribute Width
+        {
+            get => GetAttribute<DotNodeWidthAttribute>();
+            set => SetAttribute(value);
+        }
+
         public DotNodeHeightAttribute Height
         {
             get => GetAttribute<DotNodeHeightAttribute>();


### PR DESCRIPTION
Not sure if there's a reason why the width attribute didn't exist, but I thought, I'll just add it. 🙂 