### PR TITLE
Add support for style attribute on edges

### DIFF
--- a/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
+++ b/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
@@ -143,6 +143,25 @@ namespace DotNetGraph.Tests.Edge
         }
 
         [Fact]
+        public void EdgeWithStyle()
+        {
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotEdge("hello", "world")
+                    {
+                        Style = DotEdgeStyle.Dashed
+                    }
+                }
+            };
+
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[style=dashed]; }");
+        }
+
+        [Fact]
         public void EdgeWithArrowHead()
         {
             var graph = new DotGraph("TestGraph")

--- a/Sources/DotNetGraph/Attributes/DotEdgeStyleAttribute.cs
+++ b/Sources/DotNetGraph/Attributes/DotEdgeStyleAttribute.cs
@@ -1,0 +1,19 @@
+﻿using DotNetGraph.Edge;
+
+namespace DotNetGraph.Attributes
+{
+    public class DotEdgeStyleAttribute : DotColorAttribute
+    {
+        public DotEdgeStyle Style { get; set; }
+
+        public DotEdgeStyleAttribute(DotEdgeStyle style = default)
+        {
+            Style = style;
+        }
+
+        public static implicit operator DotEdgeStyleAttribute(DotEdgeStyle? style)
+        {
+            return style.HasValue ? new DotEdgeStyleAttribute(style.Value) : null;
+        }
+    }
+}

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -174,6 +174,10 @@ namespace DotNetGraph.Compiler
                 {
                     attributeValues.Add($"style={nodeStyleAttribute.Style.ToString().ToLowerInvariant()}");
                 }
+                else if (attribute is DotEdgeStyleAttribute edgeStyleAttribute)
+                {
+                    attributeValues.Add($"style={edgeStyleAttribute.Style.ToString().ToLowerInvariant()}");
+                }
                 else if (attribute is DotFontColorAttribute fontColorAttribute)
                 {
                     attributeValues.Add($"fontcolor=\"{fontColorAttribute.ToHex()}\"");

--- a/Sources/DotNetGraph/Edge/DotEdge.cs
+++ b/Sources/DotNetGraph/Edge/DotEdge.cs
@@ -20,7 +20,13 @@ namespace DotNetGraph.Edge
             get => GetAttribute<DotFontColorAttribute>();
             set => SetAttribute(value);
         }
-        
+
+        public DotEdgeStyleAttribute Style
+        {
+            get => GetAttribute<DotEdgeStyleAttribute>();
+            set => SetAttribute(value);
+        }
+
         public DotLabelAttribute Label
         {
             get => GetAttribute<DotLabelAttribute>();


### PR DESCRIPTION
I noticed that the style attribute for edges is for some reason not supported. I have therefore made these changes, which are analogous to the style attribute of nodes