### PR TITLE
Add support for PenWidth attribute on nodes and edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ var myNode = new DotNode("MyNode")
     FontColor = Color.Black,
     Style = DotNodeStyle.Dotted,
     Width = 0.5f,
-    Height = 0.5f
+    Height = 0.5f,
+    PenWidth = 1.5f
 };
 
 // Add the node to the graph
@@ -47,7 +48,9 @@ var myEdge = new DotEdge(myNode1, myNode2)
     ArrowTail = DotEdgeArrowType.Diamond,
     Color = Color.Red,
     FontColor = Color.Black,
-    Label = "My edge!"
+    Label = "My edge!",
+    Style = DotEdgeStyle.Dashed,
+    PenWidth = 1.5f
 };
 
 // Add the edge to the graph

--- a/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
+++ b/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
@@ -139,7 +139,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[penwidth=0.46]; }");
+            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[penwidth=0.46]; }");
         }
 
         [Fact]

--- a/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
+++ b/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
@@ -124,6 +124,25 @@ namespace DotNetGraph.Tests.Edge
         }
 
         [Fact]
+        public void EdgeWithPenWidth()
+        {
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotEdge("hello", "world")
+                    {
+                        PenWidth = 0.46f
+                    }
+                }
+            };
+
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[penwidth=0.46]; }");
+        }
+
+        [Fact]
         public void EdgeWithLabel()
         {
             var graph = new DotGraph("TestGraph")

--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -174,7 +174,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [penwidth=0.64]; }");
+            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[penwidth=0.64]; }");
         }
 
         [Fact]

--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -157,7 +157,26 @@ namespace DotNetGraph.Tests.Node
 
             Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [label=\"Hello, \\\"world\\\"!\"]; }");
         }
-        
+
+        [Fact]
+        public void NodeWithPenWidth()
+        {
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotNode("TestNode")
+                    {
+                        PenWidth = 0.64f
+                    }
+                }
+            };
+
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode [penwidth=0.64]; }");
+        }
+
         [Fact]
         public void NodeWithWidth()
         {

--- a/Sources/DotNetGraph/Attributes/DotPenWidthAttribute.cs
+++ b/Sources/DotNetGraph/Attributes/DotPenWidthAttribute.cs
@@ -1,0 +1,24 @@
+﻿using DotNetGraph.Core;
+
+namespace DotNetGraph.Attributes
+{
+    public class DotPenWidthAttribute : IDotAttribute
+    {
+        public float Value { get; set; }
+
+        public DotPenWidthAttribute(float value = default)
+        {
+            Value = value;
+        }
+
+        public static implicit operator DotPenWidthAttribute(float? value)
+        {
+            return value.HasValue ? new DotPenWidthAttribute(value.Value) : null;
+        }
+
+        public static implicit operator DotPenWidthAttribute(int? value)
+        {
+            return value.HasValue ? new DotPenWidthAttribute(value.Value) : null;
+        }
+    }
+}

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -203,6 +203,10 @@ namespace DotNetGraph.Compiler
                 {
                     attributeValues.Add(string.Format(CultureInfo.InvariantCulture, "height={0:F2}", nodeHeightAttribute.Value));
                 }
+                else if (attribute is DotPenWidthAttribute dotPenwidthAttribute)
+                {
+                    attributeValues.Add(string.Format(CultureInfo.InvariantCulture, "penwidth={0:F2}", dotPenwidthAttribute.Value));
+                }
                 else if (attribute is DotEdgeArrowTailAttribute edgeArrowTailAttribute)
                 {
                     attributeValues.Add($"arrowtail={edgeArrowTailAttribute.ArrowType.ToString().ToLowerInvariant()}");

--- a/Sources/DotNetGraph/Edge/DotEdge.cs
+++ b/Sources/DotNetGraph/Edge/DotEdge.cs
@@ -32,7 +32,13 @@ namespace DotNetGraph.Edge
             get => GetAttribute<DotLabelAttribute>();
             set => SetAttribute(value);
         }
-        
+
+        public DotPenWidthAttribute PenWidth
+        {
+            get => GetAttribute<DotPenWidthAttribute>();
+            set => SetAttribute(value);
+        }
+
         public DotEdgeArrowHeadAttribute ArrowHead
         {
             get => GetAttribute<DotEdgeArrowHeadAttribute>();

--- a/Sources/DotNetGraph/Node/DotNode.cs
+++ b/Sources/DotNetGraph/Node/DotNode.cs
@@ -49,6 +49,12 @@ namespace DotNetGraph.Node
             set => SetAttribute(value);
         }
 
+        public DotPenWidthAttribute PenWidth
+        {
+            get => GetAttribute<DotPenWidthAttribute>();
+            set => SetAttribute(value);
+        }
+
         public DotNodeHeightAttribute Height
         {
             get => GetAttribute<DotNodeHeightAttribute>();


### PR DESCRIPTION
Since I need the attribute penwidth, but it hasn't been implemented yet, I thought I would just add it. Penwidth is available for both edges and nodes