### PR TITLE
 Automatically surround identifiers & attributes with double quotes

### DIFF
--- a/Sources/DotNetGraph.Tests/BasicGraphTests.cs
+++ b/Sources/DotNetGraph.Tests/BasicGraphTests.cs
@@ -16,7 +16,7 @@ namespace DotNetGraph.Tests
 
             Check.That(compiled).HasSameValueAs("graph \"My test graph\" { }");
         }
-        
+
         [Fact]
         public void EmptyDirectedGraph()
         {
@@ -24,7 +24,7 @@ namespace DotNetGraph.Tests
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("digraph \"TestGraph\" { }");
+            Check.That(compiled).HasSameValueAs("digraph TestGraph { }");
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace DotNetGraph.Tests
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { }");
         }
 
         [Fact]
@@ -47,14 +47,14 @@ namespace DotNetGraph.Tests
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("strict graph \"TestGraph\" { }");
+            Check.That(compiled).HasSameValueAs("strict graph TestGraph { }");
         }
 
         [Fact]
         public void GraphWithoutStringsFormat()
         {
             var graph = new DotGraph("TestGraph", true);
-            
+
             graph.Elements.Add(new DotNode("TestNode")
             {
                 Label = "\\lTesting"
@@ -62,7 +62,7 @@ namespace DotNetGraph.Tests
 
             var compiled = graph.Compile(false, false);
 
-            Check.That(compiled).HasSameValueAs("digraph \"TestGraph\" { \"TestNode\"[label=\"\\lTesting\"]; }");
+            Check.That(compiled).HasSameValueAs("digraph TestGraph { TestNode[label=\"\\lTesting\"]; }");
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/DotCompilerTests.cs
+++ b/Sources/DotNetGraph.Tests/DotCompilerTests.cs
@@ -1,4 +1,4 @@
-using DotNetGraph.Compiler;
+﻿using DotNetGraph.Compiler;
 using NFluent;
 using Xunit;
 
@@ -9,7 +9,7 @@ namespace DotNetGraph.Tests
         [Fact]
         public void Format()
         {
-            var text = "Je m'appelle \"Jack\",\r\n je suis un test\\essai\nCela marche!";
+            const string text = "Je m'appelle \"Jack\",\r\n je suis un test\\essai\nCela marche!";
 
             var formatted = DotCompiler.FormatString(text, true);
 
@@ -19,11 +19,37 @@ namespace DotNetGraph.Tests
         [Fact]
         public void Format_Disabled()
         {
-            var text = "Je m'appelle \"Jack\",\r\n je suis un test\\essai\nCela marche!";
+            const string text = "Je m'appelle \"Jack\",\r\n je suis un test\\essai\nCela marche!";
 
             var formatted = DotCompiler.FormatString(text, false);
 
             Check.That(formatted).HasSameValueAs(text);
+        }
+
+        [Theory]
+        [InlineData("node")]
+        [InlineData("node123")]
+        [InlineData("узел")]
+        [InlineData("節点")]
+        public void SurroundWithDoubleQuotes_Without(string text)
+        {
+            var formatted = DotCompiler.SurroundStringWithQuotes(text, false);
+
+            Check.That(formatted).HasSameValueAs(text);
+        }
+
+        [Theory]
+        [InlineData("no[]de")]
+        [InlineData("no\"de")]
+        [InlineData("no\nde")]
+        [InlineData("identifier with space")]
+        [InlineData("\"node\"")]
+        [InlineData("節+点")]
+        public void SurroundWithDoubleQuotes_With(string text)
+        {
+            var formatted = DotCompiler.SurroundStringWithQuotes(text, false);
+
+            Check.That(formatted).HasSameValueAs("\"" + text + "\"");
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/DotCompilerTests.cs
+++ b/Sources/DotNetGraph.Tests/DotCompilerTests.cs
@@ -50,6 +50,10 @@ namespace DotNetGraph.Tests
         [InlineData("\"node\"")]
         [InlineData("節点")]
         [InlineData("узел")]
+        [InlineData("1a")]
+        [InlineData("-1a")]
+        [InlineData("1.1a")]
+        [InlineData("-1.1a")]
         public void SurroundWithDoubleQuotes_With(string text)
         {
             var formatted = DotCompiler.SurroundStringWithQuotes(text, false);

--- a/Sources/DotNetGraph.Tests/DotCompilerTests.cs
+++ b/Sources/DotNetGraph.Tests/DotCompilerTests.cs
@@ -29,8 +29,11 @@ namespace DotNetGraph.Tests
         [Theory]
         [InlineData("node")]
         [InlineData("node123")]
-        [InlineData("узел")]
-        [InlineData("節点")]
+        [InlineData("underscores_are_allowed")]
+        [InlineData("-123")]
+        [InlineData("123")]
+        [InlineData("1.23")]
+        [InlineData("-1.23")]
         public void SurroundWithDoubleQuotes_Without(string text)
         {
             var formatted = DotCompiler.SurroundStringWithQuotes(text, false);
@@ -42,9 +45,11 @@ namespace DotNetGraph.Tests
         [InlineData("no[]de")]
         [InlineData("no\"de")]
         [InlineData("no\nde")]
+        [InlineData("123start_with_number")]
         [InlineData("identifier with space")]
         [InlineData("\"node\"")]
-        [InlineData("節+点")]
+        [InlineData("節点")]
+        [InlineData("узел")]
         public void SurroundWithDoubleQuotes_With(string text)
         {
             var formatted = DotCompiler.SurroundStringWithQuotes(text, false);

--- a/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
+++ b/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
@@ -23,7 +23,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world; }");
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("digraph \"TestGraph\" { \"hello\" -> \"world\"; }");
+            Check.That(compiled).HasSameValueAs("digraph TestGraph { hello -> world; }");
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\"; \"world\"; \"hello\" -- \"world\"; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello; world; hello -- world; }");
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[color=\"#FF0000\",arrowhead=box,arrowtail=diamond]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[color=\"#FF0000\",arrowhead=box,arrowtail=diamond]; }");
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[color=\"#FF0000\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[color=\"#FF0000\"]; }");
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[fontcolor=\"#0000FF\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[fontcolor=\"#0000FF\"]; }");
         }
 
         [Fact]
@@ -140,9 +140,9 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[pos=\"4,2!\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[pos=\"4,2!\"]; }");
         }
-        
+
         [Fact]
         public void EdgeWithPenWidth()
         {
@@ -159,7 +159,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[penwidth=0.46]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[penwidth=0.46]; }");
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[label=\"Hello, \\\"world\\\"!\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[label=\"Hello, \\\"world\\\"!\"]; }");
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[style=dashed]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[style=dashed]; }");
         }
 
         [Fact]
@@ -216,7 +216,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[arrowhead=box]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[arrowhead=box]; }");
         }
 
         [Fact]
@@ -235,7 +235,7 @@ namespace DotNetGraph.Tests.Edge
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"hello\" -- \"world\"[arrowtail=diamond]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[arrowtail=diamond]; }");
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/Indentation/IndentedGraphTests.cs
+++ b/Sources/DotNetGraph.Tests/Indentation/IndentedGraphTests.cs
@@ -17,17 +17,17 @@ namespace DotNetGraph.Tests.Indentation
         {
             _output = output;
         }
-        
+
         [Fact]
         public void BasicIndentedGraph()
         {
             var graph = new DotGraph("TestGraph");
 
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
-            
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \n}");
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { \n}");
         }
 
         [Fact]
@@ -36,24 +36,24 @@ namespace DotNetGraph.Tests.Indentation
             var graph = new DotGraph("TestGraph", true);
 
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
 
-            Check.That(compiled).HasSameValueAs("digraph \"TestGraph\" { \n}");
+            Check.That(compiled).HasSameValueAs("digraph TestGraph { \n}");
         }
 
         [Fact]
         public void BasicIndentedEdge()
         {
             var graph = new DotGraph("TestGraph");
-            
+
             graph.Elements.Add(new DotEdge("A", "B"));
 
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \n\t\"A\" -- \"B\"; \n}");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { \n\tA -- B; \n}");
         }
 
         [Fact]
@@ -66,28 +66,28 @@ namespace DotNetGraph.Tests.Indentation
                 Style = DotEdgeStyle.Dashed,
                 Color = Color.Red
             };
-            
+
             graph.Elements.Add(edge);
 
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \n\t\"A\" -- \"B\"[style=dashed,color=\"#FF0000\"]; \n}");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { \n\tA -- B[style=dashed,color=\"#FF0000\"]; \n}");
         }
 
         [Fact]
         public void BasicIndentedSubGraph()
         {
             var graph = new DotGraph("TestGraph");
-            
+
             graph.Elements.Add(new DotSubGraph("TestSubGraph"));
-            
+
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \n\tsubgraph \"TestSubGraph\" { \n\t} \n}");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { \n\tsubgraph TestSubGraph { \n\t} \n}");
         }
 
         [Fact]
@@ -96,30 +96,30 @@ namespace DotNetGraph.Tests.Indentation
             var graph = new DotGraph("TestGraph");
 
             var subGraph = new DotSubGraph("TestSubGraph");
-            
+
             subGraph.Elements.Add(new DotEdge("A", "B"));
-            
+
             graph.Elements.Add(subGraph);
-            
+
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \n\tsubgraph \"TestSubGraph\" { \n\t\t\"A\" -- \"B\"; \n\t} \n}");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { \n\tsubgraph TestSubGraph { \n\t\tA -- B; \n\t} \n}");
         }
-        
+
         [Fact]
         public void BasicIndentedNode()
         {
             var graph = new DotGraph("TestGraph");
-            
+
             graph.Elements.Add(new DotNode("TestNode"));
 
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \n\t\"TestNode\"; \n}");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { \n\tTestNode; \n}");
         }
 
         [Fact]
@@ -132,14 +132,14 @@ namespace DotNetGraph.Tests.Indentation
                 Color = Color.Red,
                 Style = DotNodeStyle.Bold
             };
-            
+
             graph.Elements.Add(edge);
 
             var compiled = graph.Compile(true);
-            
+
             _output.WriteLine(compiled);
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \n\t\"TestNode\"[color=\"#FF0000\",style=bold]; \n}");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { \n\tTestNode[color=\"#FF0000\",style=bold]; \n}");
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -24,7 +24,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode; }");
         }
 
         [Fact]
@@ -42,10 +42,10 @@ namespace DotNetGraph.Tests.Node
                     }
                 }
             };
-            
+
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[color=\"#0000FF\",label=\"Test\",shape=box]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[color=\"#0000FF\",label=Test,shape=box]; }");
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[color=\"#FF0000\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[color=\"#FF0000\"]; }");
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[pos=\"4,2!\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[pos=\"4,2!\"]; }");
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[shape=square]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[shape=square]; }");
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[style=dashed]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[style=dashed]; }");
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[fontcolor=\"#FF0000\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[fontcolor=\"#FF0000\"]; }");
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[fillcolor=\"#FF0000\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[fillcolor=\"#FF0000\"]; }");
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[label=\"Hello, \\\"world\\\"!\"]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[label=\"Hello, \\\"world\\\"!\"]; }");
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[penwidth=0.64]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[penwidth=0.64]; }");
         }
 
         [Fact]
@@ -213,9 +213,9 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[width=0.64]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[width=0.64]; }");
         }
-        
+
         [Fact]
         public void NodeWithHeight()
         {
@@ -232,15 +232,15 @@ namespace DotNetGraph.Tests.Node
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[height=0.64]; }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[height=0.64]; }");
         }
-        
+
         [Fact]
         public void NodeWithWidthAndHeightUsesCorrectCulture()
         {
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
-            
+
             var graph = new DotGraph("TestGraph")
             {
                 Elements =
@@ -256,21 +256,21 @@ namespace DotNetGraph.Tests.Node
             var cultureInfo = new CultureInfo("de-DE");
             Thread.CurrentThread.CurrentCulture = cultureInfo;
             Thread.CurrentThread.CurrentUICulture = cultureInfo;
-            
+
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[width=0.46,height=0.64]; }");
-            
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[width=0.46,height=0.64]; }");
+
             Thread.CurrentThread.CurrentCulture = currentCulture;
             Thread.CurrentThread.CurrentUICulture = currentUiCulture;
         }
-        
+
         [Fact]
         public void NodeWithLargeHeightUsesCorrectCulture()
         {
             var currentCulture = Thread.CurrentThread.CurrentCulture;
             var currentUiCulture = Thread.CurrentThread.CurrentUICulture;
-            
+
             var graph = new DotGraph("TestGraph")
             {
                 Elements =
@@ -285,11 +285,11 @@ namespace DotNetGraph.Tests.Node
             var cultureInfo = new CultureInfo("fr-FR");
             Thread.CurrentThread.CurrentCulture = cultureInfo;
             Thread.CurrentThread.CurrentUICulture = cultureInfo;
-            
+
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { \"TestNode\"[height=12345.67]; }");
-            
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[height=12345.67]; }");
+
             Thread.CurrentThread.CurrentCulture = currentCulture;
             Thread.CurrentThread.CurrentUICulture = currentUiCulture;
         }

--- a/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
+++ b/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
@@ -23,7 +23,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"TestSubGraph\" { } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { } }");
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"My test subgraph\" { } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph \"My test subgraph\" { } }");
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"TestSubGraph\" { style=dashed; color=\"#FF0000\"; label=\"Hello, world!\"; } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { style=dashed; color=\"#FF0000\"; label=\"Hello, world!\"; } }");
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"TestSubGraph\" { style=dashed; } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { style=dashed; } }");
         }
 
         [Fact]
@@ -98,7 +98,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"TestSubGraph\" { label=\"Hello, \\\"world\\\"!\"; } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { label=\"Hello, \\\"world\\\"!\"; } }");
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"TestSubGraph\" { color=\"#FF0000\"; } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { color=\"#FF0000\"; } }");
         }
 
         [Fact]
@@ -139,9 +139,9 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"TestSubGraph\" { \"hello\" -- \"world\"; } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { hello -- world; } }");
         }
-        
+
         [Fact]
         public void SubGraphWithEdgeDirected()
         {
@@ -162,7 +162,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("digraph \"TestGraph\" { subgraph \"TestSubGraph\" { \"hello\" -> \"world\"; } }");
+            Check.That(compiled).HasSameValueAs("digraph TestGraph { subgraph TestSubGraph { hello -> world; } }");
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace DotNetGraph.Tests.SubGraph
 
             var compiled = graph.Compile();
 
-            Check.That(compiled).HasSameValueAs("graph \"TestGraph\" { subgraph \"TestSubGraph\" { \"TestNode\"; } }");
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { TestNode; } }");
         }
     }
 }

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -15,7 +15,7 @@ namespace DotNetGraph.Compiler
 {
     public class DotCompiler
     {
-        private static readonly Regex ValidIdentifierPattern = new Regex("^([a-zA-Z\\200-\\377_][a-zA-Z\\200-\\3770-9_]*|[-]?(.[0-9]+|[0-9]+(.[0-9]*)?))$");
+        private static readonly Regex ValidIdentifierPattern = new Regex("^([a-zA-Z\\200-\\377_][a-zA-Z\\200-\\3770-9_]*|[-]?(.[0-9]+|[0-9]+(.[0-9]+)?))$");
 
         private readonly DotGraph _graph;
 

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using DotNetGraph.Attributes;
 using DotNetGraph.Core;
@@ -19,7 +20,7 @@ namespace DotNetGraph.Compiler
         {
             _graph = graph;
         }
-        
+
         public string Compile(bool indented = false, bool formatStrings = true)
         {
             var builder = new StringBuilder();
@@ -32,18 +33,18 @@ namespace DotNetGraph.Compiler
         private void CompileGraph(StringBuilder builder, bool indented, bool formatStrings)
         {
             var indentationLevel = 0;
-            
+
             if (_graph.Strict)
                 builder.Append("strict ");
 
             builder.Append(_graph.Directed ? "digraph " : "graph ");
 
-            builder.Append($"\"{FormatString(_graph.Identifier, formatStrings)}\" {{ ");
+            builder.Append($"{SurroundStringWithQuotes(_graph.Identifier, formatStrings)} {{ ");
 
             builder.AddIndentationNewLine(indented);
-            
+
             indentationLevel++;
-            
+
             foreach (var element in _graph.Elements)
             {
                 if (element is DotEdge edge)
@@ -65,22 +66,22 @@ namespace DotNetGraph.Compiler
             }
 
             indentationLevel--;
-            
+
             builder.Append("}");
         }
 
         private void CompileSubGraph(StringBuilder builder, DotSubGraph subGraph, bool indented, int indentationLevel, bool formatStrings)
         {
             builder.AddIndentation(indented, indentationLevel);
-            
-            builder.Append($"subgraph \"{FormatString(subGraph.Identifier, formatStrings)}\" {{ ");
+
+            builder.Append($"subgraph {SurroundStringWithQuotes(subGraph.Identifier, formatStrings)} {{ ");
 
             builder.AddIndentationNewLine(indented);
 
             indentationLevel++;
-            
+
             CompileSubGraphAttributes(builder, subGraph.Attributes, formatStrings);
-            
+
             foreach (var element in subGraph.Elements)
             {
                 if (element is DotEdge edge)
@@ -102,9 +103,9 @@ namespace DotNetGraph.Compiler
             }
 
             indentationLevel--;
-            
+
             builder.AddIndentation(indented, indentationLevel);
-            
+
             builder.Append("} ");
 
             builder.AddIndentationNewLine(indented);
@@ -114,7 +115,7 @@ namespace DotNetGraph.Compiler
         {
             if (attributes.Count == 0)
                 return;
-            
+
             foreach (var attribute in attributes)
             {
                 if (attribute is DotSubGraphStyleAttribute subGraphStyleAttribute)
@@ -127,7 +128,7 @@ namespace DotNetGraph.Compiler
                 }
                 else if (attribute is DotLabelAttribute labelAttribute)
                 {
-                    builder.Append($"label=\"{FormatString(labelAttribute.Text, formatStrings)}\"; ");
+                    builder.Append($"label={SurroundStringWithQuotes(labelAttribute.Text, formatStrings)}; ");
                 }
                 else
                 {
@@ -139,15 +140,15 @@ namespace DotNetGraph.Compiler
         private void CompileEdge(StringBuilder builder, DotEdge edge, bool indented, int indentationLevel, bool formatStrings)
         {
             builder.AddIndentation(indented, indentationLevel);
-            
+
             CompileEdgeEndPoint(builder, edge.Left, formatStrings);
 
             builder.Append(_graph.Directed ? " -> " : " -- ");
 
             CompileEdgeEndPoint(builder, edge.Right, formatStrings);
-            
+
             CompileAttributes(builder, edge.Attributes, formatStrings);
-            
+
             builder.Append("; ");
 
             builder.AddIndentationNewLine(indented);
@@ -157,11 +158,11 @@ namespace DotNetGraph.Compiler
         {
             if (endPoint is DotString leftEdgeString)
             {
-                builder.Append($"\"{FormatString(leftEdgeString.Value, formatStrings)}\"");
+                builder.Append(SurroundStringWithQuotes(leftEdgeString.Value, formatStrings));
             }
             else if (endPoint is DotNode leftEdgeNode)
             {
-                builder.Append($"\"{FormatString(leftEdgeNode.Identifier, formatStrings)}\"");
+                builder.Append(SurroundStringWithQuotes(leftEdgeNode.Identifier, formatStrings));
             }
             else
             {
@@ -172,11 +173,11 @@ namespace DotNetGraph.Compiler
         private void CompileNode(StringBuilder builder, DotNode node, bool indented, int indentationLevel, bool formatStrings)
         {
             builder.AddIndentation(indented, indentationLevel);
-            
-            builder.Append($"\"{FormatString(node.Identifier, formatStrings)}\"");
+
+            builder.Append(SurroundStringWithQuotes(node.Identifier, formatStrings));
 
             CompileAttributes(builder, node.Attributes, formatStrings);
-            
+
             builder.Append("; ");
 
             builder.AddIndentationNewLine(indented);
@@ -190,7 +191,7 @@ namespace DotNetGraph.Compiler
             builder.Append("[");
 
             var attributeValues = new List<string>();
-            
+
             foreach (var attribute in attributes)
             {
                 if (attribute is DotNodeShapeAttribute nodeShapeAttribute)
@@ -219,7 +220,7 @@ namespace DotNetGraph.Compiler
                 }
                 else if (attribute is DotLabelAttribute labelAttribute)
                 {
-                    attributeValues.Add($"label=\"{FormatString(labelAttribute.Text, formatStrings)}\"");
+                    attributeValues.Add($"label={SurroundStringWithQuotes(labelAttribute.Text, formatStrings)}");
                 }
                 else if (attribute is DotNodeWidthAttribute nodeWidthAttribute)
                 {
@@ -252,22 +253,27 @@ namespace DotNetGraph.Compiler
             }
 
             builder.Append(string.Join(",", attributeValues));
-            
+
             builder.Append("]");
+        }
+
+        internal static string SurroundStringWithQuotes(string value, bool format)
+        {
+            var formatted = FormatString(value, format);
+            var surround = value.Any(c => !char.IsLetterOrDigit(c) || char.IsWhiteSpace(c));
+            return surround ? "\"" + formatted + "\"" : formatted;
         }
 
         internal static string FormatString(string value, bool format)
         {
             if (!format)
                 return value;
-            
-            var result = value
+
+            return value
                 .Replace("\\", "\\\\")
                 .Replace("\"", "\\\"")
                 .Replace("\r\n", "\\n")
                 .Replace("\n", "\\n");
-
-            return result;
         }
     }
 }

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using DotNetGraph.Attributes;
 using DotNetGraph.Core;
 using DotNetGraph.Edge;
@@ -14,6 +15,8 @@ namespace DotNetGraph.Compiler
 {
     public class DotCompiler
     {
+        private static readonly Regex ValidIdentifierPattern = new Regex("^([a-zA-Z\\200-\\377_][a-zA-Z\\200-\\3770-9_]*|[-]?(.[0-9]+|[0-9]+(.[0-9]*)?))$");
+
         private readonly DotGraph _graph;
 
         public DotCompiler(DotGraph graph)
@@ -260,8 +263,7 @@ namespace DotNetGraph.Compiler
         internal static string SurroundStringWithQuotes(string value, bool format)
         {
             var formatted = FormatString(value, format);
-            var surround = value.Any(c => !char.IsLetterOrDigit(c) || char.IsWhiteSpace(c));
-            return surround ? "\"" + formatted + "\"" : formatted;
+            return ValidIdentifierPattern.IsMatch(value) ? formatted : "\"" + formatted + "\"";
         }
 
         internal static string FormatString(string value, bool format)


### PR DESCRIPTION
Changed DotCompiler to only surround identifiers and labels with double quotes when necessary.

Reasons for this change:
 - Makes it possible to assign default attributes to nodes, edges, etc:
   ```csharp
   new DotNode("node")
   {
       Label = "example"
   };

   // before: "node"[label="example"];
   // after: node[label=example];
   ```
 - Output without unnecessary double quotes is less verbose

I have used the Regex pattern described here: https://graphviz.org/doc/info/lang.html

Issue: #25 