### PR TITLE
Added support for multiple styles

### DIFF
--- a/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
+++ b/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
@@ -201,6 +201,25 @@ namespace DotNetGraph.Tests.Edge
         }
 
         [Fact]
+        public void EdgeWithMultipleStyles()
+        {
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotEdge("hello", "world")
+                    {
+                        Style = DotEdgeStyle.Dashed | DotEdgeStyle.Dotted
+                    }
+                }
+            };
+
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[style=\"dashed,dotted\"]; }");
+        }
+
+        [Fact]
         public void EdgeWithArrowHead()
         {
             var graph = new DotGraph("TestGraph")

--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -122,6 +122,25 @@ namespace DotNetGraph.Tests.Node
         }
 
         [Fact]
+        public void NodeWithMultipleStyles()
+        {
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotNode("TestNode")
+                    {
+                        Style = DotNodeStyle.Rounded | DotNodeStyle.Filled
+                    }
+                }
+            };
+
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { TestNode[style=\"rounded,filled\"]; }");
+        }
+
+        [Fact]
         public void NodeWithFontColor()
         {
             var graph = new DotGraph("TestGraph")

--- a/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
+++ b/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
@@ -83,6 +83,25 @@ namespace DotNetGraph.Tests.SubGraph
         }
 
         [Fact]
+        public void SubGraphWithMultipleStyles()
+        {
+            var graph = new DotGraph("TestGraph")
+            {
+                Elements =
+                {
+                    new DotSubGraph("TestSubGraph")
+                    {
+                        Style = DotSubGraphStyle.Rounded | DotSubGraphStyle.Filled
+                    }
+                }
+            };
+
+            var compiled = graph.Compile();
+
+            Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { style=\"rounded,filled\"; } }");
+        }
+
+        [Fact]
         public void SubGraphWithLabel()
         {
             var graph = new DotGraph("TestGraph")

--- a/Sources/DotNetGraph/Compiler/DotCompiler.cs
+++ b/Sources/DotNetGraph/Compiler/DotCompiler.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using DotNetGraph.Attributes;
@@ -123,7 +122,7 @@ namespace DotNetGraph.Compiler
             {
                 if (attribute is DotSubGraphStyleAttribute subGraphStyleAttribute)
                 {
-                    builder.Append($"style={subGraphStyleAttribute.Style.ToString().ToLowerInvariant()}; ");
+                    builder.Append($"style={SurroundStringWithQuotes(subGraphStyleAttribute.Style.FlagsToString(), formatStrings)}; ");
                 }
                 else if (attribute is DotColorAttribute colorAttribute)
                 {
@@ -203,11 +202,11 @@ namespace DotNetGraph.Compiler
                 }
                 else if (attribute is DotNodeStyleAttribute nodeStyleAttribute)
                 {
-                    attributeValues.Add($"style={nodeStyleAttribute.Style.ToString().ToLowerInvariant()}");
+                    attributeValues.Add($"style={SurroundStringWithQuotes(nodeStyleAttribute.Style.FlagsToString(), formatStrings)}");
                 }
                 else if (attribute is DotEdgeStyleAttribute edgeStyleAttribute)
                 {
-                    attributeValues.Add($"style={edgeStyleAttribute.Style.ToString().ToLowerInvariant()}");
+                    attributeValues.Add($"style={SurroundStringWithQuotes(edgeStyleAttribute.Style.FlagsToString(), formatStrings)}");
                 }
                 else if (attribute is DotFontColorAttribute fontColorAttribute)
                 {

--- a/Sources/DotNetGraph/Edge/DotEdgeStyle.cs
+++ b/Sources/DotNetGraph/Edge/DotEdgeStyle.cs
@@ -1,10 +1,13 @@
+using System;
+
 namespace DotNetGraph.Edge
 {
+    [Flags]
     public enum DotEdgeStyle
     {
-        Solid,
-        Dashed,
-        Dotted,
-        Bold
+        Solid = 1,
+        Dashed = 2,
+        Dotted = 4,
+        Bold = 8
     }
 }

--- a/Sources/DotNetGraph/Extensions/EnumExtensions.cs
+++ b/Sources/DotNetGraph/Extensions/EnumExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Linq;
+
+namespace DotNetGraph.Extensions
+{
+    internal static class EnumExtensions
+    {
+        public static string FlagsToString<T>(this T @enum) where T : Enum
+        {
+            return string.Join(",", Enum.GetValues(typeof(T))
+                .Cast<T>()
+                .Where(a => @enum.HasFlag(a))
+                .Select(a => a.ToString().ToLowerInvariant()));
+        }
+    }
+}

--- a/Sources/DotNetGraph/Node/DotNodeStyle.cs
+++ b/Sources/DotNetGraph/Node/DotNodeStyle.cs
@@ -1,15 +1,18 @@
+using System;
+
 namespace DotNetGraph.Node
 {
+    [Flags]
     public enum DotNodeStyle
     {
-        Solid,
-        Dashed,
-        Dotted,
-        Bold,
-        Rounded,
-        Diagonals,
-        Filled,
-        Striped,
-        Wedged
+        Solid = 1,
+        Dashed = 2,
+        Dotted = 4,
+        Bold = 8,
+        Rounded = 16,
+        Diagonals = 32,
+        Filled = 64,
+        Striped = 128,
+        Wedged = 256
     }
 }

--- a/Sources/DotNetGraph/SubGraph/DotSubGraphStyle.cs
+++ b/Sources/DotNetGraph/SubGraph/DotSubGraphStyle.cs
@@ -1,13 +1,16 @@
+using System;
+
 namespace DotNetGraph.SubGraph
 {
+    [Flags]
     public enum DotSubGraphStyle
     {
-        Solid,
-        Dashed,
-        Dotted,
-        Bold,
-        Rounded,
-        Filled,
-        Striped
+        Solid = 1,
+        Dashed = 2,
+        Dotted = 4,
+        Bold = 8,
+        Rounded = 16,
+        Filled = 32,
+        Striped = 64
     }
 }


### PR DESCRIPTION
Makes it possible to assign multiple styles to nodes, edges, and subgraphs.

`DotNode.Style = DotNodeStyle.Rounded | DotNodeStyle.Filled;`

Related issue #25 