### PR TITLE
Added null checks for DotNode and DotEdge

### DIFF
--- a/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
+++ b/Sources/DotNetGraph.Tests/Edge/BasicEdgeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using DotNetGraph.Core;
 using DotNetGraph.Edge;
@@ -236,6 +237,36 @@ namespace DotNetGraph.Tests.Edge
             var compiled = graph.Compile();
 
             Check.That(compiled).HasSameValueAs("graph TestGraph { hello -- world[arrowtail=diamond]; }");
+        }
+
+        [Fact]
+        public void EdgeWithNullNodesThrowsException()
+        {
+            var node = new DotNode("example");
+
+            Check.ThatCode(() => new DotEdge(null, node)).Throws<ArgumentNullException>();
+            Check.ThatCode(() => new DotEdge(node, null)).Throws<ArgumentNullException>();
+
+            Check.ThatCode(() => new DotEdge(null, "test")).Throws<ArgumentNullException>();
+            Check.ThatCode(() => new DotEdge("test", null)).Throws<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void EdgeWithEmptyNodeIdentifierThrowsException()
+        {
+            Check.ThatCode(() => new DotEdge(string.Empty, "test")).Throws<ArgumentException>();
+            Check.ThatCode(() => new DotEdge(" ", "test")).Throws<ArgumentException>();
+            Check.ThatCode(() => new DotEdge("test", string.Empty)).Throws<ArgumentException>();
+            Check.ThatCode(() => new DotEdge("test", " ")).Throws<ArgumentException>();
+        }
+
+        [Fact]
+        public void ModifyEdgeWithNullNodesThrowsException()
+        {
+            var edge = new DotEdge(new DotNode("left"), new DotNode("right"));
+
+            Check.ThatCode(() => edge.Left = null).Throws<ArgumentNullException>();
+            Check.ThatCode(() => edge.Right = null).Throws<ArgumentNullException>();
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -296,7 +296,7 @@ namespace DotNetGraph.Tests.Node
         }
 
         [Fact]
-        public void NodeWithoutIdentifierThrowsException()
+        public void NodeWithNullIdentifierThrowsException()
         {
             Check.ThatCode(() => new DotNode(null)).Throws<ArgumentNullException>();
         }
@@ -306,6 +306,21 @@ namespace DotNetGraph.Tests.Node
         {
             Check.ThatCode(() => new DotNode(string.Empty)).Throws<ArgumentException>();
             Check.ThatCode(() => new DotNode(" ")).Throws<ArgumentException>();
+        }
+
+        [Fact]
+        public void ModifyNodeIdentifierWithNullIdentifierThrowsException()
+        {
+            var node = new DotNode("test");
+            Check.ThatCode(() => node.Identifier = null).Throws<ArgumentException>();
+        }
+
+        [Fact]
+        public void ModifyNodeIdentifierWithEmptyIdentifierThrowsException()
+        {
+            var node = new DotNode("test");
+            Check.ThatCode(() => node.Identifier = string.Empty).Throws<ArgumentException>();
+            Check.ThatCode(() => node.Identifier = " ").Throws<ArgumentException>();
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Node/BasicNodeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using System.Globalization;
 using System.Threading;
@@ -292,6 +293,19 @@ namespace DotNetGraph.Tests.Node
 
             Thread.CurrentThread.CurrentCulture = currentCulture;
             Thread.CurrentThread.CurrentUICulture = currentUiCulture;
+        }
+
+        [Fact]
+        public void NodeWithoutIdentifierThrowsException()
+        {
+            Check.ThatCode(() => new DotNode(null)).Throws<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void NodeWithEmptyIdentifierThrowsException()
+        {
+            Check.ThatCode(() => new DotNode(string.Empty)).Throws<ArgumentException>();
+            Check.ThatCode(() => new DotNode(" ")).Throws<ArgumentException>();
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
+++ b/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using DotNetGraph.Edge;
 using DotNetGraph.Extensions;
@@ -185,6 +186,27 @@ namespace DotNetGraph.Tests.SubGraph
             var compiled = graph.Compile();
 
             Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { TestNode; } }");
+        }
+
+        [Fact]
+        public void EdgeWithNullNodesThrowsException()
+        {
+            var node = new DotNode("example");
+
+            Check.ThatCode(() => new DotEdge(null, node)).Throws<ArgumentNullException>();
+            Check.ThatCode(() => new DotEdge(node, null)).Throws<ArgumentNullException>();
+
+            Check.ThatCode(() => new DotEdge(null, "test")).Throws<ArgumentNullException>();
+            Check.ThatCode(() => new DotEdge("test", null)).Throws<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void EdgeWithEmptyNodeIdentifierThrowsException()
+        {
+            Check.ThatCode(() => new DotEdge(string.Empty, "test")).Throws<ArgumentException>();
+            Check.ThatCode(() => new DotEdge(" ", "test")).Throws<ArgumentException>();
+            Check.ThatCode(() => new DotEdge("test", string.Empty)).Throws<ArgumentException>();
+            Check.ThatCode(() => new DotEdge("test", " ")).Throws<ArgumentException>();
         }
     }
 }

--- a/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
+++ b/Sources/DotNetGraph.Tests/SubGraph/BasicSubGraphTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Drawing;
 using DotNetGraph.Edge;
 using DotNetGraph.Extensions;
@@ -186,27 +185,6 @@ namespace DotNetGraph.Tests.SubGraph
             var compiled = graph.Compile();
 
             Check.That(compiled).HasSameValueAs("graph TestGraph { subgraph TestSubGraph { TestNode; } }");
-        }
-
-        [Fact]
-        public void EdgeWithNullNodesThrowsException()
-        {
-            var node = new DotNode("example");
-
-            Check.ThatCode(() => new DotEdge(null, node)).Throws<ArgumentNullException>();
-            Check.ThatCode(() => new DotEdge(node, null)).Throws<ArgumentNullException>();
-
-            Check.ThatCode(() => new DotEdge(null, "test")).Throws<ArgumentNullException>();
-            Check.ThatCode(() => new DotEdge("test", null)).Throws<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void EdgeWithEmptyNodeIdentifierThrowsException()
-        {
-            Check.ThatCode(() => new DotEdge(string.Empty, "test")).Throws<ArgumentException>();
-            Check.ThatCode(() => new DotEdge(" ", "test")).Throws<ArgumentException>();
-            Check.ThatCode(() => new DotEdge("test", string.Empty)).Throws<ArgumentException>();
-            Check.ThatCode(() => new DotEdge("test", " ")).Throws<ArgumentException>();
         }
     }
 }

--- a/Sources/DotNetGraph/Core/DotPosition.cs
+++ b/Sources/DotNetGraph/Core/DotPosition.cs
@@ -3,7 +3,7 @@ namespace DotNetGraph.Core
     public class DotPosition
     {
         public int X { get; set; }
-        
+
         public int Y { get; set; }
 
         public DotPosition()

--- a/Sources/DotNetGraph/DotGraph.cs
+++ b/Sources/DotNetGraph/DotGraph.cs
@@ -6,11 +6,11 @@ namespace DotNetGraph
     public class DotGraph : IDotElement
     {
         public bool Directed { get; set; }
-        
+
         public string Identifier { get; set; }
-        
+
         public bool Strict { get; set; }
-        
+
         public List<IDotElement> Elements { get; }
 
         public DotGraph()

--- a/Sources/DotNetGraph/Edge/DotEdge.cs
+++ b/Sources/DotNetGraph/Edge/DotEdge.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using DotNetGraph.Attributes;
 using DotNetGraph.Core;
@@ -7,7 +8,7 @@ namespace DotNetGraph.Edge
     public class DotEdge : DotElementWithAttributes
     {
         public IDotElement Left { get; set; }
-        
+
         public IDotElement Right { get; set; }
 
         public DotColorAttribute Color
@@ -15,7 +16,7 @@ namespace DotNetGraph.Edge
             get => GetAttribute<DotColorAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotFontColorAttribute FontColor
         {
             get => GetAttribute<DotFontColorAttribute>();
@@ -45,31 +46,43 @@ namespace DotNetGraph.Edge
             get => GetAttribute<DotEdgeArrowHeadAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotEdgeArrowTailAttribute ArrowTail
         {
             get => GetAttribute<DotEdgeArrowTailAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotPositionAttribute Position
         {
             get => GetAttribute<DotPositionAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotEdge()
         {
         }
-        
+
         public DotEdge(IDotElement left, IDotElement right)
         {
-            Left = left;
-            Right = right;
+            Left = left ?? throw new ArgumentNullException(nameof(left));
+            Right = right ?? throw new ArgumentNullException(nameof(right));
         }
 
         public DotEdge(string left, string right)
         {
+            if (left == null)
+                throw new ArgumentNullException(nameof(left));
+
+            if (right == null)
+                throw new ArgumentNullException(nameof(right));
+
+            if (left.Trim().Length == 0)
+                throw new ArgumentException("Left node cannot be empty", nameof(left));
+
+            if (right.Trim().Length == 0)
+                throw new ArgumentException("Right node cannot be empty", nameof(right));
+
             Left = new DotString(left);
             Right = new DotString(right);
         }

--- a/Sources/DotNetGraph/Edge/DotEdge.cs
+++ b/Sources/DotNetGraph/Edge/DotEdge.cs
@@ -7,9 +7,20 @@ namespace DotNetGraph.Edge
 {
     public class DotEdge : DotElementWithAttributes
     {
-        public IDotElement Left { get; set; }
+        private IDotElement _left;
+        private IDotElement _right;
 
-        public IDotElement Right { get; set; }
+        public IDotElement Left
+        {
+            get => _left;
+            set => _left = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public IDotElement Right
+        {
+            get => _right;
+            set => _right = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         public DotColorAttribute Color
         {
@@ -59,10 +70,6 @@ namespace DotNetGraph.Edge
             set => SetAttribute(value);
         }
 
-        public DotEdge()
-        {
-        }
-
         public DotEdge(IDotElement left, IDotElement right)
         {
             Left = left ?? throw new ArgumentNullException(nameof(left));
@@ -77,11 +84,11 @@ namespace DotNetGraph.Edge
             if (right == null)
                 throw new ArgumentNullException(nameof(right));
 
-            if (left.Trim().Length == 0)
-                throw new ArgumentException("Left node cannot be empty", nameof(left));
+            if (string.IsNullOrWhiteSpace(left))
+                throw new ArgumentException("Node cannot be empty", nameof(left));
 
-            if (right.Trim().Length == 0)
-                throw new ArgumentException("Right node cannot be empty", nameof(right));
+            if (string.IsNullOrWhiteSpace(right))
+                throw new ArgumentException("Node cannot be empty", nameof(right));
 
             Left = new DotString(left);
             Right = new DotString(right);

--- a/Sources/DotNetGraph/Node/DotNode.cs
+++ b/Sources/DotNetGraph/Node/DotNode.cs
@@ -6,7 +6,22 @@ namespace DotNetGraph.Node
 {
     public class DotNode : DotElementWithAttributes
     {
-        public string Identifier { get; set; }
+        private string _identifier;
+
+        public string Identifier
+        {
+            get => _identifier;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new ArgumentException("Identifier cannot be empty", nameof(value));
+
+                _identifier = value;
+            }
+        }
 
         public DotColorAttribute Color
         {
@@ -73,7 +88,7 @@ namespace DotNetGraph.Node
             if (identifier == null)
                 throw new ArgumentNullException(nameof(identifier));
 
-            if (identifier.Trim().Length == 0)
+            if (string.IsNullOrWhiteSpace(identifier))
                 throw new ArgumentException("Identifier cannot be empty", nameof(identifier));
 
             Identifier = identifier;

--- a/Sources/DotNetGraph/Node/DotNode.cs
+++ b/Sources/DotNetGraph/Node/DotNode.cs
@@ -1,5 +1,6 @@
 using DotNetGraph.Attributes;
 using DotNetGraph.Core;
+using System;
 
 namespace DotNetGraph.Node
 {
@@ -12,13 +13,13 @@ namespace DotNetGraph.Node
             get => GetAttribute<DotColorAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotFontColorAttribute FontColor
         {
             get => GetAttribute<DotFontColorAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotFillColorAttribute FillColor
         {
             get => GetAttribute<DotFillColorAttribute>();
@@ -30,7 +31,7 @@ namespace DotNetGraph.Node
             get => GetAttribute<DotNodeShapeAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotNodeStyleAttribute Style
         {
             get => GetAttribute<DotNodeStyleAttribute>();
@@ -66,9 +67,15 @@ namespace DotNetGraph.Node
             get => GetAttribute<DotPositionAttribute>();
             set => SetAttribute(value);
         }
-        
-        public DotNode(string identifier = null, DotColorAttribute color = null)
+
+        public DotNode(string identifier, DotColorAttribute color = null)
         {
+            if (identifier == null)
+                throw new ArgumentNullException(nameof(identifier));
+
+            if (identifier.Trim().Length == 0)
+                throw new ArgumentException("Identifier cannot be empty", nameof(identifier));
+
             Identifier = identifier;
             Color = color;
         }

--- a/Sources/DotNetGraph/SubGraph/DotSubGraph.cs
+++ b/Sources/DotNetGraph/SubGraph/DotSubGraph.cs
@@ -7,19 +7,19 @@ namespace DotNetGraph.SubGraph
     public class DotSubGraph : DotElementWithAttributes
     {
         public string Identifier { get; set; }
-        
+
         public DotColorAttribute Color
         {
             get => GetAttribute<DotColorAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotSubGraphStyleAttribute Style
         {
             get => GetAttribute<DotSubGraphStyleAttribute>();
             set => SetAttribute(value);
         }
-        
+
         public DotLabelAttribute Label
         {
             get => GetAttribute<DotLabelAttribute>();


### PR DESCRIPTION
I just remembered being confused about a null reference exception at first in `DotCompiler`. I have removed the empty constructor for `DotNode`, and added proper null / empty checks.