### PR TITLE
Add explicit name parameter

### DIFF
--- a/Sources/DotNetGraph.Tests/Core/DotNodeTests.cs
+++ b/Sources/DotNetGraph.Tests/Core/DotNodeTests.cs
@@ -39,4 +39,17 @@ public class DotNodeTests
         var result = writer.GetStringBuilder().ToString();
         result.Should().Be("Test [\n\t\"color\"=\"#FF0000\"\n]\n");
     }
+
+    [TestMethod]
+    public async Task CompileNodesProperties()
+    {
+        var node = new DotNode()
+            .WithIdentifier("node", quoteReservedWords: false).WithStyle(DotNodeStyle.Filled);
+        await using var writer = new StringWriter();
+        var context = new CompilationContext(writer, new CompilationOptions());
+        await node.CompileAsync(context);
+
+        var result = writer.GetStringBuilder().ToString();
+        result.Should().Be("node [\n\t\"style\"=\"filled\"\n]\n");
+    }
 }

--- a/Sources/DotNetGraph/Core/DotIdentifier.cs
+++ b/Sources/DotNetGraph/Core/DotIdentifier.cs
@@ -9,6 +9,8 @@ namespace DotNetGraph.Core
 {
     public class DotIdentifier : IDotElement, IEquatable<DotIdentifier>
     {
+        private readonly bool _quoteReservedWords;
+
         private static readonly Regex NoQuotesRequiredRegex
             = new Regex("^([a-zA-Z\\200-\\377_][a-zA-Z\\200-\\3770-9_]*|[-]?(.[0-9]+|[0-9]+(.[0-9]+)?))$");
 
@@ -26,8 +28,9 @@ namespace DotNetGraph.Core
 
         public bool IsHtml { get; set; } = false;
 
-        public DotIdentifier(string value, bool isHtml = false)
+        public DotIdentifier(string value, bool isHtml = false, bool quoteReservedWords = true)
         {
+            _quoteReservedWords = quoteReservedWords;
             Value = value;
             IsHtml = isHtml;
         }
@@ -41,7 +44,7 @@ namespace DotNetGraph.Core
             }
 
             var value = context.Options.AutomaticEscapedCharactersFormat ? Value.FormatGraphvizEscapedCharacters() : Value;
-            if (RequiresDoubleQuotes(value))
+            if (RequiresDoubleQuotes(value) && _quoteReservedWords)
                 await context.TextWriter.WriteAsync($"\"{value}\"");
             else
                 await context.TextWriter.WriteAsync($"{value}");

--- a/Sources/DotNetGraph/Extensions/DotNodeExtensions.cs
+++ b/Sources/DotNetGraph/Extensions/DotNodeExtensions.cs
@@ -5,9 +5,10 @@ namespace DotNetGraph.Extensions
 {
     public static class DotNodeExtensions
     {
-        public static DotNode WithIdentifier(this DotNode node, string identifier, bool isHtml = false)
+        public static DotNode WithIdentifier(this DotNode node, string identifier, bool isHtml = false,
+            bool quoteReservedWords = true)
         {
-            node.Identifier = new DotIdentifier(identifier, isHtml);
+            node.Identifier = new DotIdentifier(identifier, isHtml, quoteReservedWords);
             return node;
         }
 


### PR DESCRIPTION
I would like to cover next case which I'm actively use to minimize the dot files:

```dot
digraph name {
    fontsize=48
    bgcolor="transparent"

    rankdir=LR;
    node [shape=box, style="rounded,filled", fillcolor="#333333", fontcolor="#ffffff"];

    {node [fillcolor="#952877"; color="#952877"]; purple} // <- this will be applied to all nodes in same group
    purple [label="Purple background with rounded corners"]
}
```

I propose to do minimal changes and extend DotNode element to accept any name including ones that needs to be quoted.